### PR TITLE
CD-1675 Replace msg -> message in errors, sort imports

### DIFF
--- a/src/maptiler/cloud_cli/base.py
+++ b/src/maptiler/cloud_cli/base.py
@@ -1,15 +1,13 @@
-import urllib.parse
 import re
-
-from uuid import UUID
+import urllib.parse
 from pathlib import Path
 from time import sleep
 from typing import Optional
+from uuid import UUID
 
 import click
 import requests
-
-from requests import Response, HTTPError
+from requests import HTTPError, Response
 
 
 class URLGenerator:
@@ -142,5 +140,5 @@ def handle_response_errors(response: Response):
         response.raise_for_status()
     except HTTPError as error:
         print(error)
-        print(error.response.json()["errors"][0]["msg"])
+        print(error.response.json()["errors"][0]["message"])
         exit()


### PR DESCRIPTION
- Sort imports in `base.py`
- Replace Desktop -> Engine in readme
- Use `message` instead of `msg` key when printing errors to the user