### PR TITLE
CD-2128 Retry on closed connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 __pycache__/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The command will print out the tileset ID on the last line.
 > :information_source: The GeoPackage must have a tile matrix set. Read the
 > [Vector tiles generating (basic)](https://documentation.maptiler.com/hc/en-us/articles/360020887038-Vector-tiles-generating-basic-)
 > article to learn how to create a valid GeoPackage or MBTiles from the
-> [MapTiler Desktop application](https://www.maptiler.com/desktop/).
+> [MapTiler Engine application](https://www.maptiler.com/engine/).
 
 > :bulb: If you reach the tileset limit for your account, you will not be able to upload new tilesets, and you will get an error.
 > Check out our [plans](https://www.maptiler.com/cloud/plans/) to increase the number of tilesets you can have.


### PR DESCRIPTION
CD-2128

Retry on `ConnectionResetError` when requesting ingest data. 

I am unsure if the [`Retry`](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry) module can be used here. The documentation talks about connection errors, which happen before the server processes the request, but that is not the case here. 

I have also renamed Desktop -> Engine in the readme file, added .DS_store to gitignore