### PR TITLE
CL-733 Ingest document ID does not exist until ingest is completed

### DIFF
--- a/src/maptiler/cloud_cli/base.py
+++ b/src/maptiler/cloud_cli/base.py
@@ -49,7 +49,7 @@ class S3UploadResult:
 @dataclass
 class IngestResponse:
     id: UUID
-    document_id: UUID
+    document_id: Optional[UUID]
     state: str
     upload: Union[S3Upload, GoogleDriveUpload, None]
     errors: list[Error]
@@ -117,9 +117,13 @@ class Client:
         else:
             errors = []
 
+        document_id = data.get("document_id")
+        if document_id is not None:
+            document_id = UUID(document_id)
+        
         return IngestResponse(
             id=UUID(data["id"]),
-            document_id=UUID(data["document_id"]),
+            document_id=document_id,
             state=data["state"],
             upload=upload,
             errors=errors,


### PR DESCRIPTION
CL-733

### Objective
Bring the internal data model of Cloud API responses in line with changes made in CL-733.

### Description
Make the `document_id` attribute optional. It is not present in the response until ingest is completed successfully.